### PR TITLE
Fix: Correct NameObject handling in PyPDFParser for image filters

### DIFF
--- a/libs/community/langchain_community/document_loaders/parsers/pdf.py
+++ b/libs/community/langchain_community/document_loaders/parsers/pdf.py
@@ -446,13 +446,20 @@ class PyPDFParser(BaseBlobParser):
 
                     # Handle cases where Filter might be a list or a single NameObject
                     if isinstance(img_filter_obj, pypdf.generic.ArrayObject):
-                        # Taking the first filter if multiple are present, common for e.g. FlateDecode
                         if not img_filter_obj: # Empty filter array
-                             logger.warning(f"PyPDFParser: Skipping image ({obj_name}) due to empty /Filter array.")
-                             continue
-                        img_filter = img_filter_obj[0].name[1:] if img_filter_obj[0].name else ""
+                            logger.warning(f"PyPDFParser: Skipping image ({obj_name}) due to empty /Filter array.")
+                            continue
+                        # Get the first filter name from the array
+                        first_filter_in_array = img_filter_obj[0]
+                        if isinstance(first_filter_in_array, pypdf.generic.NameObject):
+                            filter_val = str(first_filter_in_array)
+                            img_filter = filter_val[1:] if filter_val.startswith("/") else filter_val
+                        else:
+                            logger.warning(f"PyPDFParser: Skipping image ({obj_name}) as first element in /Filter array is not a NameObject: {type(first_filter_in_array)}.")
+                            continue
                     elif isinstance(img_filter_obj, pypdf.generic.NameObject):
-                        img_filter = img_filter_obj.name[1:] if img_filter_obj.name else ""
+                        filter_val = str(img_filter_obj)
+                        img_filter = filter_val[1:] if filter_val.startswith("/") else filter_val
                     else:
                         logger.warning(f"PyPDFParser: Skipping image ({obj_name}) due to unknown /Filter type: {type(img_filter_obj)}.")
                         continue


### PR DESCRIPTION
This commit fixes an error in PyPDFParser where an attempt was made to access a non-existent `.name` attribute on a `pypdf.generic.NameObject` when extracting image filter names. The correct way to get the string value of a NameObject is to convert it directly to a string (e.g., `str(name_object)`).

Changes:
- Modified `PyPDFParser.extract_images_from_page` to use `str(filter_name_obj)` to get the filter name string (e.g., "/FlateDecode").
- Ensured that the leading slash is removed from the filter name.
- Added checks for empty filter arrays and non-NameObject elements within filter arrays.

This resolves the error "AttributeError: 'NameObject' object has no attribute 'name'" and improves the robustness of image filter parsing.